### PR TITLE
feat: 테이블 스키마 설계를 JPA 엔티티에 적용

### DIFF
--- a/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
+++ b/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
@@ -4,6 +4,7 @@ import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -21,7 +22,7 @@ public class Calendar {
     @Column(name = "CALENDAR_ID")
     private String id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 

--- a/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
+++ b/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
@@ -2,7 +2,9 @@ package com.adventours.calendar.calendar.domain;
 
 import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -16,10 +18,11 @@ public class Calendar {
 
     //TODO: UUID pk 적용
     @Id
+    @Column(name = "CALENDAR_ID")
     private String id;
 
     @ManyToOne
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "userId", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
+++ b/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
@@ -1,0 +1,28 @@
+package com.adventours.calendar.calendar.domain;
+
+import com.adventours.calendar.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "CALENDAR")
+public class Calendar {
+
+    //TODO: UUID pk 적용
+    @Id
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+}

--- a/src/main/java/com/adventours/calendar/gift/domain/Comment.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Comment.java
@@ -4,6 +4,7 @@ import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,11 +23,11 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "GIFT_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Gift gift;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 

--- a/src/main/java/com/adventours/calendar/gift/domain/Comment.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Comment.java
@@ -18,15 +18,16 @@ import lombok.Getter;
 @Table(name = "COMMENT")
 public class Comment {
     @Id
+    @Column(name = "COMMENT_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
     @ManyToOne
-    @JoinColumn(name = "gift_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "GIFT_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Gift gift;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/adventours/calendar/gift/domain/Comment.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Comment.java
@@ -1,8 +1,10 @@
 package com.adventours.calendar.gift.domain;
 
-import com.adventours.calendar.calendar.domain.Calendar;
+import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,26 +15,20 @@ import lombok.Getter;
 
 @Getter
 @Entity
-@Table(name = "GIFT")
-public class Gift {
+@Table(name = "COMMENT")
+public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long commentId;
 
     @ManyToOne
-    @JoinColumn(name = "calendarId", nullable = false)
-    private Calendar calendar;
+    @JoinColumn(name = "gift_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Gift gift;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
 
     @Column(nullable = false)
-    private int day;
-
-    //TODO: Enum으로 제공
-    @Column(nullable = false)
-    private String contentType;
-
-    private String contentUrl;
-
     private String body;
-
-    // 생성자, getter 및 setter 메서드
 }

--- a/src/main/java/com/adventours/calendar/gift/domain/Gift.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Gift.java
@@ -1,0 +1,38 @@
+package com.adventours.calendar.gift.domain;
+
+import com.adventours.calendar.calendar.domain.Calendar;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "GIFT")
+public class Gift {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "calendarId")
+    private Calendar calendar;
+
+    @Column(nullable = false)
+    private int day;
+
+    //TODO: Enum으로 제공
+    @Column(nullable = false)
+    private String contentType;
+
+    private String contentUrl;
+
+    private String body;
+
+    // 생성자, getter 및 setter 메서드
+}

--- a/src/main/java/com/adventours/calendar/gift/domain/Gift.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Gift.java
@@ -2,7 +2,9 @@ package com.adventours.calendar.gift.domain;
 
 import com.adventours.calendar.calendar.domain.Calendar;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,11 +18,12 @@ import lombok.Getter;
 @Table(name = "GIFT")
 public class Gift {
     @Id
+    @Column(name = "GIFT_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "calendarId", nullable = false)
+    @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Calendar calendar;
 
     @Column(nullable = false)

--- a/src/main/java/com/adventours/calendar/gift/domain/Gift.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Gift.java
@@ -28,7 +28,7 @@ public class Gift {
     private Calendar calendar;
 
     @Column(nullable = false)
-    private int day;
+    private int days;
 
     //TODO: Enum으로 제공
     @Column(nullable = false)

--- a/src/main/java/com/adventours/calendar/gift/domain/Gift.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Gift.java
@@ -33,6 +33,4 @@ public class Gift {
     private String contentUrl;
 
     private String body;
-
-    // 생성자, getter 및 setter 메서드
 }

--- a/src/main/java/com/adventours/calendar/gift/domain/Gift.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Gift.java
@@ -4,6 +4,7 @@ import com.adventours.calendar.calendar.domain.Calendar;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,7 +23,7 @@ public class Gift {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Calendar calendar;
 

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
@@ -14,7 +14,7 @@ import org.hibernate.type.TrueFalseConverter;
 public class GiftPersonalState {
 
     @EmbeddedId
-    GiftPersonalStatePk giftPersonalStatePk;
+    private GiftPersonalStatePk giftPersonalStatePk;
 
     @Column(nullable = false, columnDefinition = "CHAR(1) DEFAULT 'N'")
     @Convert(converter = TrueFalseConverter.class)

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
@@ -1,0 +1,25 @@
+package com.adventours.calendar.gift.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import org.hibernate.type.TrueFalseConverter;
+
+@Getter
+@Entity
+@Table(name = "GIFT_PERSONAL_STATE")
+public class GiftPersonalState {
+
+    @EmbeddedId
+    GiftPersonalStatePk giftPersonalStatePk;
+
+    @Column(nullable = false, columnDefinition = "CHAR(1) DEFAULT 'N'")
+    @Convert(converter = TrueFalseConverter.class)
+    private boolean isOpened = false;
+
+    //TODO: Enum으로 제공
+    private String react;
+}

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
@@ -14,9 +14,9 @@ import java.io.Serializable;
 public class GiftPersonalStatePk implements Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="GIFT_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name="GIFT_ID", nullable = false, referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Gift gift;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="USER_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name="USER_ID", nullable = false, referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 }

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
@@ -1,0 +1,22 @@
+package com.adventours.calendar.gift.domain;
+
+import com.adventours.calendar.user.domain.User;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import java.io.Serializable;
+
+@Embeddable
+public class GiftPersonalStatePk implements Serializable {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="GIFT_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Gift gift;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="USER_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+}

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
 public class GiftPersonalStatePk implements Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="GIFT_ID", nullable = false, referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @JoinColumn(name="GIFT_ID", nullable = false, referencedColumnName = "GIFT_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Gift gift;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="USER_ID", nullable = false, referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))

--- a/src/main/java/com/adventours/calendar/letter/domain/Letter.java
+++ b/src/main/java/com/adventours/calendar/letter/domain/Letter.java
@@ -5,6 +5,7 @@ import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,11 +24,11 @@ public class Letter {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long letterId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Calendar calendar;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "FROM_USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User fromUser;
 

--- a/src/main/java/com/adventours/calendar/letter/domain/Letter.java
+++ b/src/main/java/com/adventours/calendar/letter/domain/Letter.java
@@ -1,0 +1,34 @@
+package com.adventours.calendar.letter.domain;
+
+import com.adventours.calendar.calendar.domain.Calendar;
+import com.adventours.calendar.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "LETTER")
+public class Letter {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long letterId;
+
+    @ManyToOne
+    @JoinColumn(name = "calendarId", nullable = false)
+    private Calendar calendar;
+
+    @ManyToOne
+    @JoinColumn(name = "fromUserId", nullable = false)
+    private User fromUser;
+
+    @Column(nullable = false)
+    private String body;
+
+}

--- a/src/main/java/com/adventours/calendar/letter/domain/Letter.java
+++ b/src/main/java/com/adventours/calendar/letter/domain/Letter.java
@@ -3,7 +3,9 @@ package com.adventours.calendar.letter.domain;
 import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,15 +19,16 @@ import lombok.Getter;
 @Table(name = "LETTER")
 public class Letter {
     @Id
+    @Column(name = "LETTER_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long letterId;
 
     @ManyToOne
-    @JoinColumn(name = "calendarId", nullable = false)
+    @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Calendar calendar;
 
     @ManyToOne
-    @JoinColumn(name = "fromUserId", nullable = false)
+    @JoinColumn(name = "FROM_USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User fromUser;
 
     @Column(nullable = false)

--- a/src/main/java/com/adventours/calendar/subscribe/domain/Subscribe.java
+++ b/src/main/java/com/adventours/calendar/subscribe/domain/Subscribe.java
@@ -1,0 +1,33 @@
+package com.adventours.calendar.subscribe.domain;
+
+import com.adventours.calendar.calendar.domain.Calendar;
+import com.adventours.calendar.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "SUBSCRIBE")
+public class Subscribe {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "SUBSCRIBE_ID")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Calendar calendar;
+
+    @ManyToOne
+    @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+}

--- a/src/main/java/com/adventours/calendar/subscribe/domain/Subscribe.java
+++ b/src/main/java/com/adventours/calendar/subscribe/domain/Subscribe.java
@@ -5,6 +5,7 @@ import com.adventours.calendar.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,11 +24,11 @@ public class Subscribe {
     @Column(name = "SUBSCRIBE_ID")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Calendar calendar;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 }

--- a/src/main/java/com/adventours/calendar/user/domain/User.java
+++ b/src/main/java/com/adventours/calendar/user/domain/User.java
@@ -27,12 +27,20 @@ public class User {
     @Column(nullable = false)
     private String providerId;
 
+    //TODO 기본 닉네임 부여하기 + nullable false 적용
+    @Column(unique = true)
+    private String nickname;
+
     private String profileImgUrl;
 
     public User(final OAuthProvider provider, final String providerId, final String profileImgUrl) {
         this.provider = provider;
         this.providerId = providerId;
         this.profileImgUrl = profileImgUrl;
+    }
+
+    public void updateNickname(final String nickname) {
+        this.nickname = nickname;
     }
 
     public User() {

--- a/src/main/java/com/adventours/calendar/user/domain/User.java
+++ b/src/main/java/com/adventours/calendar/user/domain/User.java
@@ -28,7 +28,7 @@ public class User {
     private String providerId;
 
     //TODO 기본 닉네임 부여하기 + nullable false 적용
-    @Column(unique = true)
+//    @Column(unique = true, nullable = false)
     private String nickname;
 
     private String profileImgUrl;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,11 @@ spring:
     hibernate:
       ddl-auto: create
     open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        default_batch_fetch_size: 1000
 
 oauth:
   kakao:


### PR DESCRIPTION
❗️ 이슈 번호
close #8 


📝 구현 내용
설계한 테이블을 JPA 엔티티로 반영합니다.

![image](https://github.com/advent-ours/advent-server/assets/76773202/d03582b4-8c31-48b8-9db1-3609c51e3a69)


``` sql
Hibernate: 
    create table calendar (
        user_id bigint not null,
        calendar_id varchar(255) not null,
        title varchar(255) not null,
        primary key (calendar_id)
    ) engine=InnoDB
Hibernate: 
    create table comment (
        comment_id bigint not null auto_increment,
        gift_id bigint not null,
        user_id bigint not null,
        body varchar(255) not null,
        primary key (comment_id)
    ) engine=InnoDB
Hibernate: 
    create table gift (
        day integer not null,
        gift_id bigint not null auto_increment,
        body varchar(255),
        calendar_id varchar(255) not null,
        content_type varchar(255) not null,
        content_url varchar(255),
        primary key (gift_id)
    ) engine=InnoDB
Hibernate: 
    create table gift_personal_state (
        is_opened enum ('F','T') not null,
        gift_id bigint not null,
        user_id bigint not null,
        react varchar(255),
        primary key (gift_id, user_id)
    ) engine=InnoDB
Hibernate: 
    create table letter (
        from_user_id bigint not null,
        letter_id bigint not null auto_increment,
        body varchar(255) not null,
        calendar_id varchar(255) not null,
        primary key (letter_id)
    ) engine=InnoDB
Hibernate: 
    create table users (
        user_id bigint not null auto_increment,
        nickname varchar(255),
        profile_img_url varchar(255),
        provider enum ('KAKAO') not null,
        provider_id varchar(255) not null,
        primary key (user_id)
    ) engine=InnoDB

```
