### PR TITLE
feat: 닉네임 수정 api 구현

### DIFF
--- a/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
+++ b/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
@@ -4,7 +4,9 @@ import com.adventours.calendar.auth.Auth;
 import com.adventours.calendar.auth.UserContext;
 import com.adventours.calendar.gift.service.GiftService;
 import com.adventours.calendar.gift.service.UpdateGiftRequest;
+import com.adventours.calendar.global.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,10 +19,11 @@ public class GiftController {
 
     @Auth
     @PostMapping("/calendar/{calendarId}/gifts/{giftId}")
-    public void updateGift(@PathVariable final Long calendarId,
-                           @PathVariable final Long giftId,
-                           @RequestBody final UpdateGiftRequest request) {
+    public ResponseEntity<CommonResponse<Void>> updateGift(@PathVariable final Long calendarId,
+                                                           @PathVariable final Long giftId,
+                                                           @RequestBody final UpdateGiftRequest request) {
         final Long userId = UserContext.getContext();
         giftService.updateGift(userId, giftId, request);
+        return ResponseEntity.ok(new CommonResponse<>());
     }
 }

--- a/src/main/java/com/adventours/calendar/user/domain/User.java
+++ b/src/main/java/com/adventours/calendar/user/domain/User.java
@@ -27,9 +27,8 @@ public class User {
     @Column(nullable = false)
     private String providerId;
 
-    //TODO 기본 닉네임 부여하기 + nullable false 적용
-//    @Column(unique = true, nullable = false)
-    private String nickname;
+    @Column(unique = true, nullable = false)
+    private String nickname = "새로운친구";
 
     private String profileImgUrl;
 

--- a/src/main/java/com/adventours/calendar/user/presentation/UserController.java
+++ b/src/main/java/com/adventours/calendar/user/presentation/UserController.java
@@ -1,16 +1,21 @@
 package com.adventours.calendar.user.presentation;
 
+import com.adventours.calendar.auth.Auth;
 import com.adventours.calendar.auth.JwtTokenDto;
 import com.adventours.calendar.auth.JwtTokenIssuer;
+import com.adventours.calendar.auth.UserContext;
 import com.adventours.calendar.global.CommonResponse;
 import com.adventours.calendar.user.domain.OAuthProvider;
 import com.adventours.calendar.user.service.LoginRequest;
 import com.adventours.calendar.user.service.LoginResponse;
+import com.adventours.calendar.user.service.UpdateNicknameRequest;
 import com.adventours.calendar.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,5 +33,13 @@ public class UserController {
         final JwtTokenDto jwtTokenDto = tokenIssuer.issueToken(response.getUserId());
         response.issueToken(jwtTokenDto);
         return ResponseEntity.ok(new CommonResponse<>(response));
+    }
+
+    @Auth
+    @PutMapping("/nickname")
+    public ResponseEntity<CommonResponse<Void>> updateNickname(@RequestBody final UpdateNicknameRequest request) {
+        final Long userId = UserContext.getContext();
+        userService.updateNickname(userId, request);
+        return ResponseEntity.ok(new CommonResponse<>());
     }
 }

--- a/src/main/java/com/adventours/calendar/user/service/UpdateNicknameRequest.java
+++ b/src/main/java/com/adventours/calendar/user/service/UpdateNicknameRequest.java
@@ -1,4 +1,4 @@
 package com.adventours.calendar.user.service;
 
-public record UpdateNicknameRequest() {
+public record UpdateNicknameRequest(String nickname) {
 }

--- a/src/main/java/com/adventours/calendar/user/service/UpdateNicknameRequest.java
+++ b/src/main/java/com/adventours/calendar/user/service/UpdateNicknameRequest.java
@@ -1,0 +1,4 @@
+package com.adventours.calendar.user.service;
+
+public record UpdateNicknameRequest() {
+}

--- a/src/main/java/com/adventours/calendar/user/service/UserService.java
+++ b/src/main/java/com/adventours/calendar/user/service/UserService.java
@@ -34,4 +34,8 @@ public class UserService {
     private OAuthRequestPort getProperProviderPort(final OAuthProvider provider) {
         return oAuthRequestPortMap.get(provider);
     }
+
+    public void updateNickname(final Long userId, final UpdateNicknameRequest request) {
+        throw new UnsupportedOperationException("UserService#updateNickname not implemented yet.")
+    }
 }

--- a/src/main/java/com/adventours/calendar/user/service/UserService.java
+++ b/src/main/java/com/adventours/calendar/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.adventours.calendar.user.domain.User;
 import com.adventours.calendar.user.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +36,9 @@ public class UserService {
         return oAuthRequestPortMap.get(provider);
     }
 
+    @Transactional
     public void updateNickname(final Long userId, final UpdateNicknameRequest request) {
-        throw new UnsupportedOperationException("UserService#updateNickname not implemented yet.")
+        final User user = userRepository.findById(userId).orElseThrow();
+        user.updateNickname(request.nickname());
     }
 }

--- a/src/test/java/com/adventours/calendar/common/Scenario.java
+++ b/src/test/java/com/adventours/calendar/common/Scenario.java
@@ -2,10 +2,15 @@ package com.adventours.calendar.common;
 
 import com.adventours.calendar.api.CreateCalendarApi;
 import com.adventours.calendar.gift.api.UpdateGiftApi;
+import com.adventours.calendar.user.api.UpdateNicknameApi;
 
 public class Scenario {
     public static CreateCalendarApi createCalendar() {
         return new CreateCalendarApi();
+    }
+
+    public static UpdateNicknameApi updateNickname() {
+        return new UpdateNicknameApi();
     }
 
     public UpdateGiftApi updateGift() {

--- a/src/test/java/com/adventours/calendar/user/UserControllerTest.java
+++ b/src/test/java/com/adventours/calendar/user/UserControllerTest.java
@@ -79,9 +79,9 @@ class UserControllerTest extends ApiTest {
     @DisplayName("닉네임 변경 성공")
     void updateNickname() {
         final Long userId = 1L;
-        final UpdateNicknameRequest request;
+        final UpdateNicknameRequest request = new UpdateNicknameRequest("updatedNickname");
         userService.updateNickname(userId, request);
 
-        assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("업데이트닉네임");
+        assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("updatedNickname");
     }
 }

--- a/src/test/java/com/adventours/calendar/user/UserControllerTest.java
+++ b/src/test/java/com/adventours/calendar/user/UserControllerTest.java
@@ -80,7 +80,15 @@ class UserControllerTest extends ApiTest {
     void updateNickname() {
         final Long userId = 1L;
         final UpdateNicknameRequest request = new UpdateNicknameRequest("updatedNickname");
-        userService.updateNickname(userId, request);
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .header("Authorization", accessToken)
+                .put("/user/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
 
         assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("updatedNickname");
     }

--- a/src/test/java/com/adventours/calendar/user/UserControllerTest.java
+++ b/src/test/java/com/adventours/calendar/user/UserControllerTest.java
@@ -6,6 +6,8 @@ import com.adventours.calendar.user.domain.OAuthProvider;
 import com.adventours.calendar.user.persistence.UserRepository;
 import com.adventours.calendar.user.service.KakaoUserInformation;
 import com.adventours.calendar.user.service.LoginRequest;
+import com.adventours.calendar.user.service.UpdateNicknameRequest;
+import com.adventours.calendar.user.service.UserService;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Disabled;
@@ -25,6 +27,8 @@ class UserControllerTest extends ApiTest {
     KakaoOAuthFeignClient kakaoInformationFeignClient;
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    UserService userService;
 
     //TODO: MockBean 초기화 현상 해결 필요.
     @Test
@@ -71,4 +75,13 @@ class UserControllerTest extends ApiTest {
 
     }
 
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void updateNickname() {
+        final Long userId = 1L;
+        final UpdateNicknameRequest request;
+        userService.updateNickname(userId, request);
+
+        assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("업데이트닉네임");
+    }
 }

--- a/src/test/java/com/adventours/calendar/user/UserControllerTest.java
+++ b/src/test/java/com/adventours/calendar/user/UserControllerTest.java
@@ -1,12 +1,12 @@
 package com.adventours.calendar.user;
 
 import com.adventours.calendar.common.ApiTest;
+import com.adventours.calendar.common.Scenario;
 import com.adventours.calendar.user.client.KakaoOAuthFeignClient;
 import com.adventours.calendar.user.domain.OAuthProvider;
 import com.adventours.calendar.user.persistence.UserRepository;
 import com.adventours.calendar.user.service.KakaoUserInformation;
 import com.adventours.calendar.user.service.LoginRequest;
-import com.adventours.calendar.user.service.UpdateNicknameRequest;
 import com.adventours.calendar.user.service.UserService;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -78,18 +78,9 @@ class UserControllerTest extends ApiTest {
     @Test
     @DisplayName("닉네임 변경 성공")
     void updateNickname() {
+        Scenario.updateNickname().request();
+
         final Long userId = 1L;
-        final UpdateNicknameRequest request = new UpdateNicknameRequest("updatedNickname");
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when()
-                .header("Authorization", accessToken)
-                .put("/user/nickname")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-
         assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("updatedNickname");
     }
 }

--- a/src/test/java/com/adventours/calendar/user/api/UpdateNicknameApi.java
+++ b/src/test/java/com/adventours/calendar/user/api/UpdateNicknameApi.java
@@ -1,0 +1,32 @@
+package com.adventours.calendar.user.api;
+
+import com.adventours.calendar.common.Scenario;
+import com.adventours.calendar.user.service.UpdateNicknameRequest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.springframework.http.HttpStatus;
+
+import static com.adventours.calendar.common.ApiTest.accessToken;
+
+public class UpdateNicknameApi {
+    private String nickname = "updatedNickname";
+
+    public static UpdateNicknameApi updateNickname() {
+        return new UpdateNicknameApi();
+    }
+
+    public Scenario request() {
+        final UpdateNicknameRequest request = new UpdateNicknameRequest(nickname);
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .header("Authorization", accessToken)
+                .put("/user/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        return new Scenario();
+    }
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #14 


📝 구현 내용
- 닉네임 업데이트 api 입니다.
- 기본 닉네임을 적용합니다.

### Request

```
Request method:	PUT
Request URI:	http://localhost:59759/user/nickname
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Authorization=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOiIxIiwiZXhwIjoxNjk2MDQ1MzA4fQ.kR3zi02UXxSJLm1G-MrJis7qXr1A6xWVkUBrtFeaEqaiPYu0xyYwOKBD4qZGFcRh
				Accept=*/*
				Content-Type=application/json
Cookies:		<none>
Multiparts:		<none>
Body:
{
    "nickname": "updatedNickname"
}
```

### Response

```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sat, 30 Sep 2023 02:41:49 GMT
Keep-Alive: timeout=60
Connection: keep-alive

{
    "status": {
        "resCode": "CAL200",
        "resMessage": "정상 처리."
    },
    "data": null
}
```