### PR TITLE
feat: 캘린더 구독 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'com.google.guava:guava:32.1.2-jre'
 	implementation 'com.auth0:java-jwt:4.3.0'
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.29'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
+++ b/src/main/java/com/adventours/calendar/calendar/domain/Calendar.java
@@ -2,6 +2,7 @@ package com.adventours.calendar.calendar.domain;
 
 import com.adventours.calendar.global.BaseTime;
 import com.adventours.calendar.user.domain.User;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -42,4 +43,10 @@ public class Calendar extends BaseTime {
         this.title = title;
     }
 
+    @VisibleForTesting
+    public Calendar(final UUID id, final User user, final String title) {
+        this.id = id;
+        this.user = user;
+        this.title = title;
+    }
 }

--- a/src/main/java/com/adventours/calendar/calendar/persistence/SubscribeRepository.java
+++ b/src/main/java/com/adventours/calendar/calendar/persistence/SubscribeRepository.java
@@ -1,0 +1,7 @@
+package com.adventours.calendar.calendar.persistence;
+
+import com.adventours.calendar.subscribe.domain.Subscribe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+}

--- a/src/main/java/com/adventours/calendar/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/adventours/calendar/calendar/presentation/CalendarController.java
@@ -5,10 +5,12 @@ import com.adventours.calendar.auth.UserContext;
 import com.adventours.calendar.calendar.service.CalendarListResponse;
 import com.adventours.calendar.calendar.service.CalendarService;
 import com.adventours.calendar.calendar.service.CreateCalendarRequest;
+import com.adventours.calendar.global.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +39,13 @@ public class CalendarController {
         final Long userId = UserContext.getContext();
         final List<CalendarListResponse> myCalendarList = calendarService.getMyCalendarList(userId);
         return ResponseEntity.ok(myCalendarList);
+    }
+
+    @Auth
+    @PostMapping("/sub/{calendarId}")
+    public ResponseEntity<CommonResponse<Void>> subscribeCalendar(@PathVariable final String calendarId) {
+        final Long userId = UserContext.getContext();
+        calendarService.subscribe(userId, calendarId);
+        return ResponseEntity.ok(new CommonResponse<>());
     }
 }

--- a/src/main/java/com/adventours/calendar/calendar/service/CalendarService.java
+++ b/src/main/java/com/adventours/calendar/calendar/service/CalendarService.java
@@ -2,9 +2,12 @@ package com.adventours.calendar.calendar.service;
 
 import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
+import com.adventours.calendar.calendar.persistence.SubscribeRepository;
 import com.adventours.calendar.exception.AlreadyExistCalendarException;
 import com.adventours.calendar.gift.domain.Gift;
 import com.adventours.calendar.gift.persistence.GiftRepository;
+import com.adventours.calendar.subscribe.domain.Subscribe;
+import com.adventours.calendar.subscribe.domain.SubscribePk;
 import com.adventours.calendar.user.domain.User;
 import com.adventours.calendar.user.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +25,7 @@ public class CalendarService {
     private final CalendarRepository calendarRepository;
     private final GiftRepository giftRepository;
     private final UserRepository userRepository;
+    private final SubscribeRepository subscribeRepository;
 
     @Transactional
     public void createCalendar(final Long userId, final CreateCalendarRequest request) {
@@ -52,5 +57,15 @@ public class CalendarService {
         final User user = userRepository.getReferenceById(userId);
         final List<Calendar> calendarList = calendarRepository.findAllByUser(user);
         return CalendarListResponse.responseToList(calendarList);
+    }
+
+    public void subscribe(final Long userId, final String calendarId) {
+        final User user = userRepository.getReferenceById(userId);
+        final Calendar calendar = calendarRepository.getReferenceById(UUID.fromString(calendarId));
+        try {
+            subscribeRepository.save(new Subscribe(new SubscribePk(user, calendar)));
+        } catch (DataIntegrityViolationException e) {
+            throw new RuntimeException();
+        }
     }
 }

--- a/src/main/java/com/adventours/calendar/subscribe/domain/Subscribe.java
+++ b/src/main/java/com/adventours/calendar/subscribe/domain/Subscribe.java
@@ -1,18 +1,8 @@
 package com.adventours.calendar.subscribe.domain;
 
-import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.global.BaseTime;
-import com.adventours.calendar.user.domain.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
@@ -20,16 +10,14 @@ import lombok.Getter;
 @Entity
 @Table(name = "SUBSCRIBE")
 public class Subscribe extends BaseTime {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "SUBSCRIBE_ID")
-    private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private Calendar calendar;
+    @EmbeddedId
+    private SubscribePk subscribePk;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private User user;
+    public Subscribe() {
+    }
+
+    public Subscribe(SubscribePk subscribePk) {
+        this.subscribePk = subscribePk;
+    }
 }

--- a/src/main/java/com/adventours/calendar/subscribe/domain/SubscribePk.java
+++ b/src/main/java/com/adventours/calendar/subscribe/domain/SubscribePk.java
@@ -1,0 +1,31 @@
+package com.adventours.calendar.subscribe.domain;
+
+import com.adventours.calendar.calendar.domain.Calendar;
+import com.adventours.calendar.user.domain.User;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import java.io.Serializable;
+
+@Embeddable
+public class SubscribePk implements Serializable {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CALENDAR_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Calendar calendar;
+
+    public SubscribePk(final User user, final Calendar calendar) {
+        this.user = user;
+        this.calendar = calendar;
+    }
+
+    public SubscribePk() {
+    }
+}

--- a/src/main/java/com/adventours/calendar/user/domain/User.java
+++ b/src/main/java/com/adventours/calendar/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.adventours.calendar.user.domain;
 
 import com.adventours.calendar.global.BaseTime;
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -36,6 +37,15 @@ public class User extends BaseTime {
     public User(final OAuthProvider provider, final String providerId, final String profileImgUrl) {
         this.provider = provider;
         this.providerId = providerId;
+        this.profileImgUrl = profileImgUrl;
+    }
+
+    @VisibleForTesting
+    public User(final Long id, final OAuthProvider provider, final String providerId, final String nickname, final String profileImgUrl) {
+        this.id = id;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
     }
 

--- a/src/test/java/com/adventours/calendar/api/CreateCalendarDB.java
+++ b/src/test/java/com/adventours/calendar/api/CreateCalendarDB.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 
 public class CreateCalendarDB {
 
-    private String uuid;
+    private UUID uuid;
     private User user;
-    private String title;
+    private String title = "title";
 
-    public CreateCalendarDB uuid(String uuid) {
+    public CreateCalendarDB uuid(UUID uuid) {
         this.uuid = uuid;
         return this;
     }
@@ -29,7 +29,7 @@ public class CreateCalendarDB {
 
     public Calendar create() {
         return DBTestUtil.calendarRepository.save(new Calendar(
-                UUID.fromString(uuid),
+                uuid,
                 user,
                 title));
     };

--- a/src/test/java/com/adventours/calendar/api/CreateCalendarDB.java
+++ b/src/test/java/com/adventours/calendar/api/CreateCalendarDB.java
@@ -1,0 +1,36 @@
+package com.adventours.calendar.api;
+
+import com.adventours.calendar.calendar.domain.Calendar;
+import com.adventours.calendar.common.DBTestUtil;
+import com.adventours.calendar.user.domain.User;
+
+import java.util.UUID;
+
+public class CreateCalendarDB {
+
+    private String uuid;
+    private User user;
+    private String title;
+
+    public CreateCalendarDB uuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    public CreateCalendarDB user(User user) {
+        this.user = user;
+        return this;
+    }
+
+    public CreateCalendarDB title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public Calendar create() {
+        return DBTestUtil.calendarRepository.save(new Calendar(
+                UUID.fromString(uuid),
+                user,
+                title));
+    };
+}

--- a/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
@@ -69,7 +69,7 @@ class CalendarControllerTest extends ApiTest {
         RestAssured.given().log().all()
                 .header("Authorization", accessToken)
                 .when()
-                .get("/calendar/sub/{calendarId}", calendar.getId())
+                .post("/calendar/sub/{calendarId}", calendar.getId())
                 .then()
                 .log().all()
                 .statusCode(200);

--- a/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
@@ -1,5 +1,6 @@
 package com.adventours.calendar.calendar;
 
+import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
 import com.adventours.calendar.calendar.persistence.SubscribeRepository;
 import com.adventours.calendar.calendar.service.CalendarService;
@@ -7,11 +8,14 @@ import com.adventours.calendar.common.ApiTest;
 import com.adventours.calendar.common.Scenario;
 import com.adventours.calendar.gift.persistence.GiftRepository;
 import com.adventours.calendar.gift.service.GiftService;
+import com.adventours.calendar.user.domain.User;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,11 +63,17 @@ class CalendarControllerTest extends ApiTest {
     @Test
     @DisplayName("캘린더 구독 성공")
     void subscribeCalendar() {
-        Scenario.createCalendar().request();
-        final String calendarId = calendarRepository.findAll().get(0).getId().toString();
+        final User user = Scenario.createUserDB().id(2L).create();
+        final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
 
-        final Long userId = 1L;
-        calendarService.subscribe(userId, calendarId);
+        RestAssured.given().log().all()
+                .header("Authorization", accessToken)
+                .when()
+                .get("/calendar/sub/{calendarId}", calendar.getId())
+                .then()
+                .log().all()
+                .statusCode(200);
+
         assertThat(subscribeRepository.count()).isOne();
     }
 }

--- a/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
@@ -1,6 +1,7 @@
 package com.adventours.calendar.calendar;
 
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
+import com.adventours.calendar.calendar.persistence.SubscribeRepository;
 import com.adventours.calendar.calendar.service.CalendarService;
 import com.adventours.calendar.common.ApiTest;
 import com.adventours.calendar.common.Scenario;
@@ -24,6 +25,8 @@ class CalendarControllerTest extends ApiTest {
     GiftService giftService;
     @Autowired
     CalendarService calendarService;
+    @Autowired
+    SubscribeRepository subscribeRepository;
 
     @Test
     @DisplayName("캘린더 생성 성공")
@@ -51,6 +54,16 @@ class CalendarControllerTest extends ApiTest {
                 .then()
                 .log().all()
                 .statusCode(200);
+    }
 
+    @Test
+    @DisplayName("캘린더 구독 성공")
+    void subscribeCalendar() {
+        Scenario.createCalendar().request();
+        final String calendarId = calendarRepository.findAll().get(0).getId().toString();
+
+        final Long userId = 1L;
+        calendarService.subscribe(userId, calendarId);
+        assertThat(subscribeRepository.count()).isOne();
     }
 }

--- a/src/test/java/com/adventours/calendar/common/ApiTest.java
+++ b/src/test/java/com/adventours/calendar/common/ApiTest.java
@@ -1,6 +1,7 @@
 package com.adventours.calendar.common;
 
 import com.adventours.calendar.auth.JwtTokenIssuer;
+import com.adventours.calendar.calendar.persistence.CalendarRepository;
 import com.adventours.calendar.user.domain.OAuthProvider;
 import com.adventours.calendar.user.domain.User;
 import com.adventours.calendar.user.persistence.UserRepository;
@@ -22,6 +23,8 @@ public class ApiTest {
     UserRepository userRepository;
     @Autowired
     JwtTokenIssuer jwtTokenIssuer;
+    @Autowired
+    CalendarRepository calendarRepository;
     public static String accessToken;
 
     @BeforeEach
@@ -33,5 +36,8 @@ public class ApiTest {
         databaseCleaner.execute();
         userRepository.save(new User(OAuthProvider.KAKAO, "providerId", "profileImage"));
         accessToken = jwtTokenIssuer.issueToken(1L).accessToken();
+
+        DBTestUtil.setUserRepository(userRepository);
+        DBTestUtil.setCalendarRepository(calendarRepository);
     }
 }

--- a/src/test/java/com/adventours/calendar/common/DBTestUtil.java
+++ b/src/test/java/com/adventours/calendar/common/DBTestUtil.java
@@ -1,0 +1,17 @@
+package com.adventours.calendar.common;
+
+import com.adventours.calendar.calendar.persistence.CalendarRepository;
+import com.adventours.calendar.user.persistence.UserRepository;
+
+public class DBTestUtil {
+    public static UserRepository userRepository;
+    public static CalendarRepository calendarRepository;
+
+    public static void setUserRepository(UserRepository userRepository) {
+        DBTestUtil.userRepository = userRepository;
+    }
+
+    public static void setCalendarRepository(CalendarRepository calendarRepository) {
+        DBTestUtil.calendarRepository = calendarRepository;
+    }
+}

--- a/src/test/java/com/adventours/calendar/common/Scenario.java
+++ b/src/test/java/com/adventours/calendar/common/Scenario.java
@@ -1,12 +1,20 @@
 package com.adventours.calendar.common;
 
 import com.adventours.calendar.api.CreateCalendarApi;
+import com.adventours.calendar.api.CreateCalendarDB;
 import com.adventours.calendar.gift.api.UpdateGiftApi;
+import com.adventours.calendar.user.api.CreateUserDB;
 import com.adventours.calendar.user.api.UpdateNicknameApi;
 
 public class Scenario {
+    public static CreateUserDB createUserDB() {
+        return new CreateUserDB();
+    }
     public static CreateCalendarApi createCalendar() {
         return new CreateCalendarApi();
+    }
+    public static CreateCalendarDB createCalendarDB() {
+        return new CreateCalendarDB();
     }
 
     public static UpdateNicknameApi updateNickname() {

--- a/src/test/java/com/adventours/calendar/user/api/CreateUserDB.java
+++ b/src/test/java/com/adventours/calendar/user/api/CreateUserDB.java
@@ -1,0 +1,49 @@
+package com.adventours.calendar.user.api;
+
+import com.adventours.calendar.common.DBTestUtil;
+import com.adventours.calendar.user.domain.OAuthProvider;
+import com.adventours.calendar.user.domain.User;
+
+public class CreateUserDB {
+
+    private Long id;
+    private OAuthProvider provider = OAuthProvider.KAKAO;
+    private String providerId = "providerId";
+    private String nickname = "nickname";
+    private String profileImgUrl = "profileImgUrl";
+
+    public CreateUserDB id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public CreateUserDB provider(OAuthProvider provider) {
+        this.provider = provider;
+        return this;
+    }
+
+    public CreateUserDB providerId(String providerId) {
+        this.providerId = providerId;
+        return this;
+    }
+
+    public CreateUserDB nickname(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
+
+    public CreateUserDB profileImgUrl(String profileImgUrl) {
+        this.profileImgUrl = profileImgUrl;
+        return this;
+    }
+
+    public User create() {
+        return DBTestUtil.userRepository.save(new User(
+                id,
+                provider,
+                providerId,
+                nickname,
+                profileImgUrl
+        ));
+    }
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #20 

📝 구현 내용
캘린더 구독을 구현합니다.

- 테스트를 위해 본인 캘린더 구독의 예외처리를 하지 않음.
- 테스트용 DB utill 구현.

### Request

```
Request method:	POST
Request URI:	http://localhost:52628/calendar/sub/c6b752b5-0c58-4930-9b59-e4cbe5f637b7
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Authorization=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOiIxIiwiZXhwIjoxNjk2MTQzNzQzfQ.hZI0VdrmriCy07XCc7FzDmcOksYwFQqLxXUTOt1uG3HQtYwwmWXeq8hZIs4bT3H8
				Accept=*/*
				Content-Type=application/x-www-form-urlencoded; charset=ISO-8859-1
Cookies:		<none>
Multiparts:		<none>
Body:			<none>
```

### Response

```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sun, 01 Oct 2023 06:02:24 GMT
Keep-Alive: timeout=60
Connection: keep-alive

{
    "status": {
        "resCode": "CAL200",
        "resMessage": "정상 처리."
    },
    "data": null
}
```

