### PR TITLE
feat: 선물 열람 api 구현

### DIFF
--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import org.hibernate.type.TrueFalseConverter;
@@ -20,6 +22,8 @@ public class GiftPersonalState {
     @Convert(converter = TrueFalseConverter.class)
     private boolean isOpened = false;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private GiftReact react = GiftReact.NONE;
 
     public GiftPersonalState() {
@@ -27,5 +31,9 @@ public class GiftPersonalState {
 
     public GiftPersonalState(final GiftPersonalStatePk giftPersonalStatePk) {
         this.giftPersonalStatePk = giftPersonalStatePk;
+    }
+
+    public void open() {
+        this.isOpened = true;
     }
 }

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
@@ -20,9 +20,12 @@ public class GiftPersonalState {
     @Convert(converter = TrueFalseConverter.class)
     private boolean isOpened = false;
 
-    private GiftReact react;
+    private GiftReact react = GiftReact.NONE;
 
     public GiftPersonalState() {
     }
 
+    public GiftPersonalState(final GiftPersonalStatePk giftPersonalStatePk) {
+        this.giftPersonalStatePk = giftPersonalStatePk;
+    }
 }

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalStatePk.java
@@ -24,4 +24,7 @@ public class GiftPersonalStatePk implements Serializable {
         this.gift = gift;
         this.user = user;
     }
+
+    public GiftPersonalStatePk() {
+    }
 }

--- a/src/main/java/com/adventours/calendar/gift/domain/GiftReact.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftReact.java
@@ -1,6 +1,7 @@
 package com.adventours.calendar.gift.domain;
 
 public enum GiftReact {
+    NONE,
     HAPPY,
     SAD,
     ANGRY,

--- a/src/main/java/com/adventours/calendar/gift/persistence/GiftRepository.java
+++ b/src/main/java/com/adventours/calendar/gift/persistence/GiftRepository.java
@@ -5,8 +5,12 @@ import com.adventours.calendar.gift.domain.Gift;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GiftRepository extends JpaRepository<Gift, Long> {
     List<Gift> findByCalendar(Calendar calendar);
 
+    Optional<Gift> findByCalendarAndDays(Calendar calendar, int days);
+
+    List<Gift> findAllByCalendar(Calendar calendar);
 }

--- a/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
+++ b/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
@@ -38,4 +38,13 @@ public class GiftController {
         final List<GiftListResponse> giftList = giftService.getGiftList(userId, calendarId);
         return ResponseEntity.ok(new CommonResponse<>(giftList));
     }
+
+    @Auth
+    @PostMapping("/calendar/{calendarId}/gift/{giftId}/open")
+    public ResponseEntity<CommonResponse<Void>> openGift(@PathVariable final String calendarId, @PathVariable final Long giftId) {
+        final Long userId = UserContext.getContext();
+        giftService.openGift(userId, giftId);
+        return ResponseEntity.ok(new CommonResponse<>());
+
+    }
 }

--- a/src/main/java/com/adventours/calendar/gift/service/GiftService.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftService.java
@@ -65,4 +65,11 @@ public class GiftService {
             );
         }).toList();
     }
+
+    public void openGift(final Long userId, final UUID calendarId, final int days) {
+        final User user = userRepository.getReferenceById(userId);
+        final Calendar calendar = calendarRepository.getReferenceById(calendarId);
+        final Gift gift = giftRepository.findByCalendarAndDays(calendar, days).orElseThrow();
+//        giftPersonalStateRepository.findBy
+    }
 }

--- a/src/main/java/com/adventours/calendar/gift/service/GiftService.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftService.java
@@ -4,6 +4,7 @@ import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
 import com.adventours.calendar.gift.domain.Gift;
 import com.adventours.calendar.gift.domain.GiftPersonalState;
+import com.adventours.calendar.gift.domain.GiftPersonalStatePk;
 import com.adventours.calendar.gift.domain.GiftReact;
 import com.adventours.calendar.gift.persistence.GiftPersonalStateRepository;
 import com.adventours.calendar.gift.persistence.GiftRepository;
@@ -66,10 +67,11 @@ public class GiftService {
         }).toList();
     }
 
-    public void openGift(final Long userId, final UUID calendarId, final int days) {
+    @Transactional
+    public void openGift(final Long userId, final Long giftId) {
         final User user = userRepository.getReferenceById(userId);
-        final Calendar calendar = calendarRepository.getReferenceById(calendarId);
-        final Gift gift = giftRepository.findByCalendarAndDays(calendar, days).orElseThrow();
-//        giftPersonalStateRepository.findBy
+        final Gift gift = giftRepository.getReferenceById(giftId);
+        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, user)).orElseThrow();
+        giftPersonalState.open();
     }
 }

--- a/src/test/java/com/adventours/calendar/api/CreateCalendarDB.java
+++ b/src/test/java/com/adventours/calendar/api/CreateCalendarDB.java
@@ -2,8 +2,11 @@ package com.adventours.calendar.api;
 
 import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.common.DBTestUtil;
+import com.adventours.calendar.gift.domain.Gift;
 import com.adventours.calendar.user.domain.User;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class CreateCalendarDB {
@@ -28,9 +31,15 @@ public class CreateCalendarDB {
     }
 
     public Calendar create() {
-        return DBTestUtil.calendarRepository.save(new Calendar(
+        final Calendar calendar = DBTestUtil.calendarRepository.save(new Calendar(
                 uuid,
                 user,
                 title));
+        List<Gift> gifts = new ArrayList<>(24);
+        for (int i = 1; i <= 24; i++) {
+            gifts.add(Gift.initOf(calendar, i));
+        }
+        DBTestUtil.giftRepository.saveAll(gifts);
+        return calendar;
     };
 }

--- a/src/test/java/com/adventours/calendar/common/ApiTest.java
+++ b/src/test/java/com/adventours/calendar/common/ApiTest.java
@@ -2,6 +2,7 @@ package com.adventours.calendar.common;
 
 import com.adventours.calendar.auth.JwtTokenIssuer;
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
+import com.adventours.calendar.gift.persistence.GiftRepository;
 import com.adventours.calendar.user.domain.OAuthProvider;
 import com.adventours.calendar.user.domain.User;
 import com.adventours.calendar.user.persistence.UserRepository;
@@ -25,6 +26,8 @@ public class ApiTest {
     JwtTokenIssuer jwtTokenIssuer;
     @Autowired
     CalendarRepository calendarRepository;
+    @Autowired
+    GiftRepository giftRepository;
     public static String accessToken;
 
     @BeforeEach
@@ -39,5 +42,6 @@ public class ApiTest {
 
         DBTestUtil.setUserRepository(userRepository);
         DBTestUtil.setCalendarRepository(calendarRepository);
+        DBTestUtil.setGiftRepository(giftRepository);
     }
 }

--- a/src/test/java/com/adventours/calendar/common/DBTestUtil.java
+++ b/src/test/java/com/adventours/calendar/common/DBTestUtil.java
@@ -1,11 +1,13 @@
 package com.adventours.calendar.common;
 
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
+import com.adventours.calendar.gift.persistence.GiftRepository;
 import com.adventours.calendar.user.persistence.UserRepository;
 
 public class DBTestUtil {
     public static UserRepository userRepository;
     public static CalendarRepository calendarRepository;
+    public static GiftRepository giftRepository;
 
     public static void setUserRepository(UserRepository userRepository) {
         DBTestUtil.userRepository = userRepository;
@@ -13,5 +15,9 @@ public class DBTestUtil {
 
     public static void setCalendarRepository(CalendarRepository calendarRepository) {
         DBTestUtil.calendarRepository = calendarRepository;
+    }
+
+    public static void setGiftRepository(GiftRepository giftRepository) {
+        DBTestUtil.giftRepository = giftRepository;
     }
 }

--- a/src/test/java/com/adventours/calendar/common/Scenario.java
+++ b/src/test/java/com/adventours/calendar/common/Scenario.java
@@ -3,6 +3,7 @@ package com.adventours.calendar.common;
 import com.adventours.calendar.api.CreateCalendarApi;
 import com.adventours.calendar.api.CreateCalendarDB;
 import com.adventours.calendar.calendar.api.SubscribeCalendarApi;
+import com.adventours.calendar.gift.api.OpenGiftApi;
 import com.adventours.calendar.gift.api.UpdateGiftApi;
 import com.adventours.calendar.user.api.CreateUserDB;
 import com.adventours.calendar.user.api.UpdateNicknameApi;
@@ -24,6 +25,10 @@ public class Scenario {
 
     public static SubscribeCalendarApi subscribeCalendar() {
         return new SubscribeCalendarApi();
+    }
+
+    public static OpenGiftApi openGift() {
+        return new OpenGiftApi();
     }
 
     public UpdateGiftApi updateGift() {

--- a/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
+++ b/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
@@ -70,21 +70,19 @@ class GiftControllerTest extends ApiTest {
         final User user = Scenario.createUserDB().id(2L).create();
         final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
         Scenario.subscribeCalendar().calendarId(calendar.getId()).request();
-
-        final Long userId = 1L;
         final Long giftId = 1L;
-        giftService.openGift(userId, giftId);
+
+        RestAssured.given().log().all()
+                .header("Authorization", accessToken)
+                .when()
+                .post("/calendar/{calendarId}/gift/{giftId}/open", calendar.getId(), giftId)
+                .then()
+                .log().all()
+                .statusCode(200);
 
         final Gift gift = giftRepository.getReferenceById(giftId);
         final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, me)).orElseThrow();
 
         assertThat(giftPersonalState.isOpened()).isTrue();
-//        RestAssured.given().log().all()
-//                .header("Authorization", accessToken)
-//                .when()
-//                .get("/calendar/{calendarId}/gift/{day}/open", calendar.getId(), 1)
-//                .then()
-//                .log().all()
-//                .statusCode(200);
     }
 }

--- a/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
+++ b/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
@@ -71,11 +71,11 @@ class GiftControllerTest extends ApiTest {
         final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
         Scenario.subscribeCalendar().calendarId(calendar.getId()).request();
 
-        final int days = 1;
         final Long userId = 1L;
-        giftService.openGift(userId, calendar.getId(), days);
+        final Long giftId = 1L;
+        giftService.openGift(userId, giftId);
 
-        final Gift gift = giftRepository.findById(1L).orElseThrow();
+        final Gift gift = giftRepository.getReferenceById(giftId);
         final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, me)).orElseThrow();
 
         assertThat(giftPersonalState.isOpened()).isTrue();

--- a/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
+++ b/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
@@ -6,7 +6,6 @@ import com.adventours.calendar.common.ApiTest;
 import com.adventours.calendar.common.Scenario;
 import com.adventours.calendar.gift.domain.Gift;
 import com.adventours.calendar.gift.domain.GiftPersonalState;
-import com.adventours.calendar.gift.domain.GiftPersonalStatePk;
 import com.adventours.calendar.gift.domain.GiftType;
 import com.adventours.calendar.gift.persistence.GiftPersonalStateRepository;
 import com.adventours.calendar.gift.persistence.GiftRepository;
@@ -66,22 +65,12 @@ class GiftControllerTest extends ApiTest {
 
     @Test
     void openGift() {
-        final User me = userRepository.getReferenceById(1L);
         final User user = Scenario.createUserDB().id(2L).create();
         final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
-        Scenario.subscribeCalendar().calendarId(calendar.getId()).request();
-        final Long giftId = 1L;
+        Scenario.subscribeCalendar().calendarId(calendar.getId()).request().
+                openGift().calendarId(calendar.getTitle()).request();
 
-        RestAssured.given().log().all()
-                .header("Authorization", accessToken)
-                .when()
-                .post("/calendar/{calendarId}/gift/{giftId}/open", calendar.getId(), giftId)
-                .then()
-                .log().all()
-                .statusCode(200);
-
-        final Gift gift = giftRepository.getReferenceById(giftId);
-        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, me)).orElseThrow();
+        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findAll().get(0);
 
         assertThat(giftPersonalState.isOpened()).isTrue();
     }

--- a/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
+++ b/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
@@ -12,6 +12,7 @@ import com.adventours.calendar.gift.persistence.GiftPersonalStateRepository;
 import com.adventours.calendar.gift.persistence.GiftRepository;
 import com.adventours.calendar.gift.service.GiftService;
 import com.adventours.calendar.user.domain.User;
+import com.adventours.calendar.user.persistence.UserRepository;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +33,7 @@ class GiftControllerTest extends ApiTest {
     GiftPersonalStateRepository giftPersonalStateRepository;
     @Autowired
     GiftService giftService;
+    @Autowired UserRepository userRepository;
 
     @Test
     @DisplayName("선물 생성/수정 성공")
@@ -64,6 +66,7 @@ class GiftControllerTest extends ApiTest {
 
     @Test
     void openGift() {
+        final User me = userRepository.getReferenceById(1L);
         final User user = Scenario.createUserDB().id(2L).create();
         final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
         Scenario.subscribeCalendar().calendarId(calendar.getId()).request();
@@ -72,10 +75,10 @@ class GiftControllerTest extends ApiTest {
         final Long userId = 1L;
         giftService.openGift(userId, calendar.getId(), days);
 
-        final Gift gift = giftRepository.getReferenceById(1L);
-        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, user)).orElseThrow();
+        final Gift gift = giftRepository.findById(1L).orElseThrow();
+        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, me)).orElseThrow();
 
-        assertThat(giftPersonalState.isOpened()).isFalse();
+        assertThat(giftPersonalState.isOpened()).isTrue();
 //        RestAssured.given().log().all()
 //                .header("Authorization", accessToken)
 //                .when()

--- a/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
+++ b/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
@@ -64,6 +64,7 @@ class GiftControllerTest extends ApiTest {
     }
 
     @Test
+    @DisplayName("선물 열기 성공")
     void openGift() {
         final User user = Scenario.createUserDB().id(2L).create();
         final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();

--- a/src/test/java/com/adventours/calendar/gift/api/OpenGiftApi.java
+++ b/src/test/java/com/adventours/calendar/gift/api/OpenGiftApi.java
@@ -1,17 +1,20 @@
-package com.adventours.calendar.calendar.api;
+package com.adventours.calendar.gift.api;
 
 import com.adventours.calendar.common.Scenario;
 import io.restassured.RestAssured;
 
-import java.util.UUID;
-
 import static com.adventours.calendar.common.ApiTest.accessToken;
 
-public class SubscribeCalendarApi {
+public class OpenGiftApi {
+    private Long giftId = 1L;
+    private String calendarId = null;
 
-    private UUID calendarId;
+    public OpenGiftApi giftId(final Long giftId) {
+        this.giftId = giftId;
+        return this;
+    }
 
-    public SubscribeCalendarApi calendarId(UUID calendarId) {
+    public OpenGiftApi calendarId(final String calendarId) {
         this.calendarId = calendarId;
         return this;
     }
@@ -21,7 +24,7 @@ public class SubscribeCalendarApi {
         RestAssured.given().log().all()
                 .header("Authorization", accessToken)
                 .when()
-                .post("/calendar/sub/{calendarId}", calendarId)
+                .post("/calendar/{calendarId}/gift/{giftId}/open", calendarId, giftId)
                 .then()
                 .log().all()
                 .statusCode(200);


### PR DESCRIPTION
❗️ 이슈 번호
close #24


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
- 선물 열람 api를 구현합니다
- 캘린더 구독 시 해당 캘린더의 선물에 대한 개개인 상태를 표시하는 giftPersonalState 24개 생성

리팩토링 필요.
giftPersonalState 에 열람과 리액션을 모두 관리할 필요가 없어 보임.

### Request

```
Request method:	POST
Request URI:	http://localhost:50178/calendar/title/gift/1/open
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Authorization=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOiIxIiwiZXhwIjoxNjk2NTA4MDk1fQ.EoQH26Dhi1j98CfrHF-dpoFFI4z7VtgNups418oJ4DlcC6cC_j9AsDuu-5WiDLq1
				Accept=*/*
				Content-Type=application/x-www-form-urlencoded; charset=ISO-8859-1
Cookies:		<none>
Multiparts:		<none>
Body:			<none>
```

### Response

```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 05 Oct 2023 11:14:57 GMT
Keep-Alive: timeout=60
Connection: keep-alive

{
    "status": {
        "resCode": "CAL200",
        "resMessage": "정상 처리."
    },
    "data": null
}
```
