### PR TITLE
feat: 회원 탈퇴 api 구현

### DIFF
--- a/src/main/java/com/adventours/calendar/user/domain/User.java
+++ b/src/main/java/com/adventours/calendar/user/domain/User.java
@@ -55,4 +55,10 @@ public class User extends BaseTime {
 
     public User() {
     }
+
+    public void withdraw() {
+        this.nickname = "탈퇴한유저";
+        this.profileImgUrl = null;
+        this.providerId = "탈퇴한유저";
+    }
 }

--- a/src/main/java/com/adventours/calendar/user/presentation/UserController.java
+++ b/src/main/java/com/adventours/calendar/user/presentation/UserController.java
@@ -12,7 +12,7 @@ import com.adventours.calendar.user.service.UpdateNicknameRequest;
 import com.adventours.calendar.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -47,6 +47,14 @@ public class UserController {
     @Auth
     @PostMapping("/logout")
     public ResponseEntity<CommonResponse<Void>> logout() {
+        return ResponseEntity.ok(new CommonResponse<>());
+    }
+
+    @Auth
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<CommonResponse<Void>> withdraw() {
+        final Long userId = UserContext.getContext();
+        userService.withdraw(userId);
         return ResponseEntity.ok(new CommonResponse<>());
     }
 }

--- a/src/main/java/com/adventours/calendar/user/service/UserService.java
+++ b/src/main/java/com/adventours/calendar/user/service/UserService.java
@@ -41,4 +41,10 @@ public class UserService {
         final User user = userRepository.findById(userId).orElseThrow();
         user.updateNickname(request.nickname());
     }
+
+    @Transactional
+    public void withdraw(final Long userId) {
+        final User user = userRepository.findById(userId).orElseThrow();
+        user.withdraw();
+    }
 }

--- a/src/test/java/com/adventours/calendar/user/UserControllerTest.java
+++ b/src/test/java/com/adventours/calendar/user/UserControllerTest.java
@@ -83,4 +83,18 @@ class UserControllerTest extends ApiTest {
         final Long userId = 1L;
         assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("updatedNickname");
     }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공")
+    void withdraw() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when()
+                .header("Authorization", accessToken)
+                .delete("/user/withdraw")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+        final Long userId = 1L;
+        assertThat(userRepository.findById(userId).get().getNickname()).isEqualTo("탈퇴한유저");
+    }
 }


### PR DESCRIPTION
❗️ 이슈 번호
close #28 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
### 현재 내부 구현

- **oauth provider 연결 정보 삭제 → 다시 로그인 시도할 경우, 회원가입 처리.**
- 닉네임이 `탈퇴한유저`로 변경 됨
- 일단 해당 유저의 개인 정보만 삭제 이후, 테스트 용으로 사용할 수 있게 api를 구현합니다.
- 추후 회의 후에 정책에 따라 유저 서비스 데이터 전체를 삭제할지에 대해서 결정합니다.

### Request

```
Request method:	DELETE
Request URI:	http://localhost:61687/user/withdraw
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Authorization=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9.eyJ1c2VySWQiOiIxIiwiZXhwIjoxNjk2NTE2MTc0fQ.i-kjZliV5tnVfdAGkVcEzYP_Sj4FWR4L6XrjRZb-P6crYoTHwT7rd945s6A8HzGz
				Accept=*/*
				Content-Type=application/json
Cookies:		<none>
Multiparts:		<none>
Body:			<none>
```

### Response

```
HTTP/1.1 200 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 05 Oct 2023 13:29:35 GMT
Keep-Alive: timeout=60
Connection: keep-alive

{
    "status": {
        "resCode": "CAL200",
        "resMessage": "정상 처리."
    },
    "data": null
}
```
