### PR TITLE
refactor: exception handler 구체화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'com.google.guava:guava:32.1.2-jre'
 	implementation 'com.auth0:java-jwt:4.3.0'

--- a/src/main/java/com/adventours/calendar/HelloController.java
+++ b/src/main/java/com/adventours/calendar/HelloController.java
@@ -1,12 +1,14 @@
 package com.adventours.calendar;
 
 import com.adventours.calendar.global.CommonResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,15 +19,21 @@ public class HelloController {
         return "진우 지호 찬희 고운 화이팅 ";
     }
 
+    @GetMapping("/exception")
+    public ResponseEntity<CommonResponse<Void>> testExceptionGet(
+            @RequestParam final String query) {
+        return ResponseEntity.ok(new CommonResponse<>());
+    }
+
     @PostMapping("/exception/{path}")
-    public ResponseEntity<CommonResponse<Void>> testException(
-            @PathVariable(required = true) final String path,
-            @RequestBody final ExceptionTestBody body) {
+    public ResponseEntity<CommonResponse<Void>> testExceptionPost(
+            @PathVariable final Long path,
+            @Valid @RequestBody final ExceptionTestBody body) {
         return ResponseEntity.ok(new CommonResponse<>());
     }
 
     public record ExceptionTestBody(
             @NotNull
-            int integerData) {
+            Integer integerData) {
     }
 }

--- a/src/main/java/com/adventours/calendar/HelloController.java
+++ b/src/main/java/com/adventours/calendar/HelloController.java
@@ -1,6 +1,12 @@
 package com.adventours.calendar;
 
+import com.adventours.calendar.global.CommonResponse;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,5 +15,17 @@ public class HelloController {
     @GetMapping("/")
     public String hello() {
         return "진우 지호 찬희 고운 화이팅 ";
+    }
+
+    @PostMapping("/exception/{path}")
+    public ResponseEntity<CommonResponse<Void>> testException(
+            @PathVariable(required = true) final String path,
+            @RequestBody final ExceptionTestBody body) {
+        return ResponseEntity.ok(new CommonResponse<>());
+    }
+
+    public record ExceptionTestBody(
+            @NotNull
+            int integerData) {
     }
 }

--- a/src/main/java/com/adventours/calendar/calendar/service/CalendarService.java
+++ b/src/main/java/com/adventours/calendar/calendar/service/CalendarService.java
@@ -4,6 +4,9 @@ import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
 import com.adventours.calendar.calendar.persistence.SubscribeRepository;
 import com.adventours.calendar.exception.AlreadyExistCalendarException;
+import com.adventours.calendar.exception.AlreadySubscribedCalendarException;
+import com.adventours.calendar.exception.NotFoundCalendarException;
+import com.adventours.calendar.exception.NotOwnerException;
 import com.adventours.calendar.gift.domain.Gift;
 import com.adventours.calendar.gift.domain.GiftPersonalState;
 import com.adventours.calendar.gift.domain.GiftPersonalStatePk;
@@ -70,7 +73,7 @@ public class CalendarService {
         try {
             subscribeRepository.save(new Subscribe(new SubscribePk(user, calendar)));
         } catch (DataIntegrityViolationException e) {
-            throw new RuntimeException();
+            throw new AlreadySubscribedCalendarException();
         }
         init24PersonalStateData(calendar, user);
     }
@@ -94,9 +97,9 @@ public class CalendarService {
 
     @Transactional
     public void updateCalendar(final Long userId, final String calendarId, final UpdateCalendarRequest request) {
-        final Calendar calendar = calendarRepository.findById(UUID.fromString(calendarId)).orElseThrow();
+        final Calendar calendar = calendarRepository.findById(UUID.fromString(calendarId)).orElseThrow(NotFoundCalendarException::new);
         if (!calendar.isOwner(userId)) {
-            throw new RuntimeException();
+            throw new NotOwnerException();
         }
         calendar.update(request.title());
     }

--- a/src/main/java/com/adventours/calendar/exception/AlreadyExistCalendarException.java
+++ b/src/main/java/com/adventours/calendar/exception/AlreadyExistCalendarException.java
@@ -2,6 +2,6 @@ package com.adventours.calendar.exception;
 
 public class AlreadyExistCalendarException extends BaseException {
     public AlreadyExistCalendarException() {
-        super(ResCode.Cal601);
+        super(ResCode.HBD801);
     }
 }

--- a/src/main/java/com/adventours/calendar/exception/AlreadySubscribedCalendarException.java
+++ b/src/main/java/com/adventours/calendar/exception/AlreadySubscribedCalendarException.java
@@ -1,0 +1,7 @@
+package com.adventours.calendar.exception;
+
+public class AlreadySubscribedCalendarException extends BaseException {
+    public AlreadySubscribedCalendarException() {
+        super(ResCode.HBD890);
+    }
+}

--- a/src/main/java/com/adventours/calendar/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/adventours/calendar/exception/CustomExceptionHandler.java
@@ -5,8 +5,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
+
+import java.net.BindException;
 
 @Slf4j
 @RestControllerAdvice
@@ -14,7 +23,7 @@ public class CustomExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
     protected CommonResponse<Void> handleCustomException(BaseException e, HttpServletRequest request) {
-        log.warn("[예외 발생] request url: {}", request.getRequestURI(), e);
+        log.info("[예외 발생] request url: {}", request.getRequestURI(), e);
         return new CommonResponse<>(e.getResCode());
     }
 
@@ -25,5 +34,20 @@ public class CustomExceptionHandler {
                 .body(new CommonResponse<>(ResCode.CAL500));
     }
 
+    @ExceptionHandler({
+            ServletRequestBindingException.class,
+            MethodArgumentTypeMismatchException.class,
+            HttpRequestMethodNotSupportedException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentNotValidException.class,
+            MultipartException.class,
+            MissingServletRequestParameterException.class,
+            BindException.class
+    })
+    protected ResponseEntity<CommonResponse<Void>> handle400Exception(Exception e, HttpServletRequest request) {
+        log.info("[잘못된 요청] request url: {}", request.getRequestURI(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new CommonResponse<>(ResCode.CAL100));
+    }
 }
 

--- a/src/main/java/com/adventours/calendar/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/adventours/calendar/exception/CustomExceptionHandler.java
@@ -31,7 +31,7 @@ public class CustomExceptionHandler {
     protected ResponseEntity<CommonResponse<Void>> handleInternalErrorException(Exception e, HttpServletRequest request) {
         log.error("[Internal Error Message] request url: {}", request.getRequestURI(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new CommonResponse<>(ResCode.CAL500));
+                .body(new CommonResponse<>(ResCode.HBD500));
     }
 
     @ExceptionHandler({
@@ -47,7 +47,7 @@ public class CustomExceptionHandler {
     protected ResponseEntity<CommonResponse<Void>> handle400Exception(Exception e, HttpServletRequest request) {
         log.info("[잘못된 요청] request url: {}", request.getRequestURI(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new CommonResponse<>(ResCode.CAL100));
+                .body(new CommonResponse<>(ResCode.HBD100));
     }
 }
 

--- a/src/main/java/com/adventours/calendar/exception/ExpiredTokenException.java
+++ b/src/main/java/com/adventours/calendar/exception/ExpiredTokenException.java
@@ -3,6 +3,6 @@ package com.adventours.calendar.exception;
 public class ExpiredTokenException extends BaseException {
 
     public ExpiredTokenException() {
-        super(ResCode.CAL301);
+        super(ResCode.HBD601);
     }
 }

--- a/src/main/java/com/adventours/calendar/exception/InvalidTokenException.java
+++ b/src/main/java/com/adventours/calendar/exception/InvalidTokenException.java
@@ -2,6 +2,6 @@ package com.adventours.calendar.exception;
 
 public class InvalidTokenException extends BaseException {
     public InvalidTokenException() {
-        super(ResCode.CAL300);
+        super(ResCode.HBD600);
     }
 }

--- a/src/main/java/com/adventours/calendar/exception/NotFoundCalendarException.java
+++ b/src/main/java/com/adventours/calendar/exception/NotFoundCalendarException.java
@@ -1,0 +1,7 @@
+package com.adventours.calendar.exception;
+
+public class NotFoundCalendarException extends BaseException {
+    public NotFoundCalendarException() {
+        super(ResCode.HBD800);
+    }
+}

--- a/src/main/java/com/adventours/calendar/exception/NotFoundGiftException.java
+++ b/src/main/java/com/adventours/calendar/exception/NotFoundGiftException.java
@@ -1,0 +1,7 @@
+package com.adventours.calendar.exception;
+
+public class NotFoundGiftException extends BaseException {
+    public NotFoundGiftException() {
+        super(ResCode.HBD850);
+    }
+}

--- a/src/main/java/com/adventours/calendar/exception/NotFoundUserException.java
+++ b/src/main/java/com/adventours/calendar/exception/NotFoundUserException.java
@@ -2,6 +2,6 @@ package com.adventours.calendar.exception;
 
 public class NotFoundUserException extends BaseException {
     public NotFoundUserException() {
-        super(ResCode.CAL400);
+        super(ResCode.HBD700);
     }
 }

--- a/src/main/java/com/adventours/calendar/exception/NotOwnerException.java
+++ b/src/main/java/com/adventours/calendar/exception/NotOwnerException.java
@@ -1,0 +1,7 @@
+package com.adventours.calendar.exception;
+
+public class NotOwnerException extends BaseException {
+    public NotOwnerException() {
+        super(ResCode.HBD701);
+    }
+}

--- a/src/main/java/com/adventours/calendar/exception/ResCode.java
+++ b/src/main/java/com/adventours/calendar/exception/ResCode.java
@@ -4,24 +4,29 @@ import org.springframework.http.HttpStatus;
 
 public enum ResCode {
 
-    //100: 클라이언트 예외
+    // 100: 클라이언트 예외
     HBD100("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
 
-    //200: 정상
+
+    // 200: 정상
     HBD200("정상 처리.", HttpStatus.OK),
 
-    //500: 서버 내부 에러
+
+    // 500: 서버 내부 에러
     HBD500("서버 내부 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
-    //600~699: 인증 예외
+
+    // 600~699: 인증 예외
     HBD600("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     HBD601("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+
 
     // 700~799: 유저 관련 예외
     HBD700("존재하지 않는 유저입니다.", HttpStatus.BAD_REQUEST),
     HBD701("해당 컨텐츠의 주인이 아닙니다.", HttpStatus.BAD_REQUEST),
 
-    //800~899: 캘린더 관련 예외
+
+    // 800~899: 캘린더 관련 예외
     HBD800("존재하지 않는 캘린더입니다.", HttpStatus.NOT_FOUND),
     HBD801("이미 존재하는 캘린더입니다.", HttpStatus.BAD_REQUEST),
     HBD850("존재하지 않는 선물입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/adventours/calendar/exception/ResCode.java
+++ b/src/main/java/com/adventours/calendar/exception/ResCode.java
@@ -5,19 +5,28 @@ import org.springframework.http.HttpStatus;
 public enum ResCode {
 
     //100: 클라이언트 예외
-    CAL100("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    HBD100("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
 
     //200: 정상
-    CAL200("정상 처리.", HttpStatus.OK),
-    //300~399: 인증 예외
-    CAL300("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    CAL301("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-    //400~499: 유저 예외
-    CAL400("존재하지 않는 유저입니다.", HttpStatus.BAD_REQUEST),
-    CAL500("서버 내부 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    //600~699: 캘린더 예외
-    Cal600("존재하지 않는 캘린더입니다.", HttpStatus.NOT_FOUND),
-    Cal601("이미 존재하는 캘린더입니다.", HttpStatus.BAD_REQUEST);
+    HBD200("정상 처리.", HttpStatus.OK),
+
+    //500: 서버 내부 에러
+    HBD500("서버 내부 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    //600~699: 인증 예외
+    HBD600("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    HBD601("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+
+    // 700~799: 유저 관련 예외
+    HBD700("존재하지 않는 유저입니다.", HttpStatus.BAD_REQUEST),
+    HBD701("해당 컨텐츠의 주인이 아닙니다.", HttpStatus.BAD_REQUEST),
+
+    //800~899: 캘린더 관련 예외
+    HBD800("존재하지 않는 캘린더입니다.", HttpStatus.NOT_FOUND),
+    HBD801("이미 존재하는 캘린더입니다.", HttpStatus.BAD_REQUEST),
+    HBD850("존재하지 않는 선물입니다.", HttpStatus.NOT_FOUND),
+    HBD890("이미 구독한 캘린더입니다.", HttpStatus.BAD_REQUEST);
+
     private final String message;
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/adventours/calendar/exception/ResCode.java
+++ b/src/main/java/com/adventours/calendar/exception/ResCode.java
@@ -4,6 +4,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ResCode {
 
+    //100: 클라이언트 예외
+    CAL100("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+
     //200: 정상
     CAL200("정상 처리.", HttpStatus.OK),
     //300~399: 인증 예외

--- a/src/main/java/com/adventours/calendar/exception/TokenNotFoundException.java
+++ b/src/main/java/com/adventours/calendar/exception/TokenNotFoundException.java
@@ -1,12 +1,9 @@
 package com.adventours.calendar.exception;
 
-import com.adventours.calendar.exception.BaseException;
-import com.adventours.calendar.exception.ResCode;
-
 public class TokenNotFoundException extends BaseException {
 
     public TokenNotFoundException() {
-        super(ResCode.CAL200);
+        super(ResCode.HBD200);
     }
 
 }

--- a/src/main/java/com/adventours/calendar/gift/service/GiftService.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftService.java
@@ -2,6 +2,8 @@ package com.adventours.calendar.gift.service;
 
 import com.adventours.calendar.calendar.domain.Calendar;
 import com.adventours.calendar.calendar.persistence.CalendarRepository;
+import com.adventours.calendar.exception.NotFoundGiftException;
+import com.adventours.calendar.exception.NotOwnerException;
 import com.adventours.calendar.gift.domain.Gift;
 import com.adventours.calendar.gift.domain.GiftPersonalState;
 import com.adventours.calendar.gift.domain.GiftPersonalStatePk;
@@ -34,12 +36,12 @@ public class GiftService {
 
     private static void validateOwnerOfGift(final long userId, final Gift gift) {
         if (!gift.getCalendar().getUser().getId().equals(userId)) {
-            throw new IllegalArgumentException("해당 캘린더의 소유자가 아닙니다.");
+            throw new NotOwnerException();
         }
     }
 
     private Gift getGift(final Long giftId) {
-        return giftRepository.findById(giftId).orElseThrow();
+        return giftRepository.findById(giftId).orElseThrow(NotFoundGiftException::new);
     }
 
     public List<GiftListResponse> getGiftList(final Long userId, final String calendarId) {

--- a/src/main/java/com/adventours/calendar/global/CommonResponse.java
+++ b/src/main/java/com/adventours/calendar/global/CommonResponse.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CommonResponse<T> {
-    private StatusResponse status = new StatusResponse(ResCode.CAL200);
+    private StatusResponse status = new StatusResponse(ResCode.HBD200);
     private final T data;
 
     public CommonResponse() {

--- a/src/main/java/com/adventours/calendar/user/service/UserService.java
+++ b/src/main/java/com/adventours/calendar/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.adventours.calendar.user.service;
 
+import com.adventours.calendar.exception.NotFoundUserException;
 import com.adventours.calendar.user.domain.OAuthProvider;
 import com.adventours.calendar.user.domain.User;
 import com.adventours.calendar.user.persistence.UserRepository;
@@ -38,13 +39,13 @@ public class UserService {
 
     @Transactional
     public void updateNickname(final Long userId, final UpdateNicknameRequest request) {
-        final User user = userRepository.findById(userId).orElseThrow();
+        final User user = userRepository.findById(userId).orElseThrow(NotFoundUserException::new);
         user.updateNickname(request.nickname());
     }
 
     @Transactional
     public void withdraw(final Long userId) {
-        final User user = userRepository.findById(userId).orElseThrow();
+        final User user = userRepository.findById(userId).orElseThrow(NotFoundUserException::new);
         user.withdraw();
     }
 }

--- a/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
@@ -74,6 +74,7 @@ class CalendarControllerTest extends ApiTest {
     }
 
     @Test
+    @DisplayName("구독 캘린더 목록 조회 성공")
     void getSubscribeList() {
         final User user = Scenario.createUserDB().id(2L).create();
         final Calendar calendar1 = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();

--- a/src/test/java/com/adventours/calendar/exception/ExceptionTest.java
+++ b/src/test/java/com/adventours/calendar/exception/ExceptionTest.java
@@ -1,11 +1,22 @@
 package com.adventours.calendar.exception;
 
+import com.adventours.calendar.HelloController;
 import com.adventours.calendar.common.ApiTest;
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 
-public class ExceptionTest extends ApiTest {
+class ExceptionTest extends ApiTest {
 
     @Test
-    void name() {
+    void ok() {
+        HelloController.ExceptionTestBody request = new HelloController.ExceptionTestBody(1);
+
+        RestAssured.given().log().all()
+                .when()
+                .body(request)
+                .contentType("application/json")
+                .post("/exception/1")
+                .then().log().all()
+                .statusCode(200);
     }
 }

--- a/src/test/java/com/adventours/calendar/exception/ExceptionTest.java
+++ b/src/test/java/com/adventours/calendar/exception/ExceptionTest.java
@@ -8,7 +8,18 @@ import org.junit.jupiter.api.Test;
 class ExceptionTest extends ApiTest {
 
     @Test
-    void ok() {
+    void ok_get() {
+        RestAssured.given().log().all()
+                .when()
+                .contentType("application/json")
+                .param("query", "query")
+                .get("/exception")
+                .then().log().all()
+                .statusCode(200);
+    }
+
+    @Test
+    void ok_post() {
         HelloController.ExceptionTestBody request = new HelloController.ExceptionTestBody(1);
 
         RestAssured.given().log().all()
@@ -18,5 +29,61 @@ class ExceptionTest extends ApiTest {
                 .post("/exception/1")
                 .then().log().all()
                 .statusCode(200);
+    }
+
+    @Test
+    void path_param() {
+        HelloController.ExceptionTestBody request = new HelloController.ExceptionTestBody(1);
+
+        RestAssured.given().log().all()
+                .when()
+                .body(request)
+                .contentType("application/json")
+                .post("/exception/error")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @Test
+    void query_param() {
+        RestAssured.given().log().all()
+                .when()
+                .contentType("application/json")
+                .get("/exception")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @Test
+    void not_allowd_method() {
+        RestAssured.given().log().all()
+                .when()
+                .contentType("application/json")
+                .delete("/exception")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @Test
+    void body_validate_noBody() {
+        RestAssured.given().log().all()
+                .when()
+                .contentType("application/json")
+                .post("/exception/1")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @Test
+    void body_validate_not_valid_body() {
+        HelloController.ExceptionTestBody request = new HelloController.ExceptionTestBody(null);
+
+        RestAssured.given().log().all()
+                .when()
+                .contentType("application/json")
+                .body(request)
+                .post("/exception/1")
+                .then().log().all()
+                .statusCode(400);
     }
 }

--- a/src/test/java/com/adventours/calendar/exception/ExceptionTest.java
+++ b/src/test/java/com/adventours/calendar/exception/ExceptionTest.java
@@ -1,0 +1,11 @@
+package com.adventours.calendar.exception;
+
+import com.adventours.calendar.common.ApiTest;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionTest extends ApiTest {
+
+    @Test
+    void name() {
+    }
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #32 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
- 400대 exception 핸들러 정의
- 기존 서비스 코드 구체화


```
// 100: 클라이언트 예외
HBD100("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),

// 200: 정상
HBD200("정상 처리.", HttpStatus.OK),

// 500: 서버 내부 에러
HBD500("서버 내부 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),

// 600~699: 인증 예외
HBD600("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
HBD601("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),

// 700~799: 유저 관련 예외
HBD700("존재하지 않는 유저입니다.", HttpStatus.BAD_REQUEST),
HBD701("해당 컨텐츠의 주인이 아닙니다.", HttpStatus.BAD_REQUEST),

// 800~899: 캘린더 관련 예외
HBD800("존재하지 않는 캘린더입니다.", HttpStatus.NOT_FOUND),
HBD801("이미 존재하는 캘린더입니다.", HttpStatus.BAD_REQUEST),
HBD850("존재하지 않는 선물입니다.", HttpStatus.NOT_FOUND),
HBD890("이미 구독한 캘린더입니다.", HttpStatus.BAD_REQUEST);
```