### PR TITLE
feat: 컨텐츠 업로드를 presigned url 기반으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 	implementation 'com.google.guava:guava:32.1.2-jre'
 	implementation 'com.auth0:java-jwt:4.3.0'
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.29'

--- a/src/main/java/com/adventours/calendar/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/adventours/calendar/calendar/presentation/CalendarController.java
@@ -2,11 +2,13 @@ package com.adventours.calendar.calendar.presentation;
 
 import com.adventours.calendar.auth.Auth;
 import com.adventours.calendar.auth.UserContext;
+import com.adventours.calendar.calendar.service.AwsS3Service;
 import com.adventours.calendar.calendar.service.CalendarService;
 import com.adventours.calendar.calendar.service.CreateCalendarRequest;
 import com.adventours.calendar.calendar.service.MyCalendarListResponse;
 import com.adventours.calendar.calendar.service.SubCalendarListResponse;
 import com.adventours.calendar.calendar.service.UpdateCalendarRequest;
+import com.adventours.calendar.calendar.service.UploadKeyResponse;
 import com.adventours.calendar.global.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -27,6 +30,13 @@ import java.util.List;
 public class CalendarController {
 
     private final CalendarService calendarService;
+    private final AwsS3Service awsS3Service;
+
+    @Auth
+    @GetMapping("/presigned-url")
+    public ResponseEntity<CommonResponse<UploadKeyResponse>> getPresignedUrl(@RequestParam(name = "file-extension") String fileExtension) {
+        return ResponseEntity.ok(new CommonResponse<>(awsS3Service.getPresignedUrl(fileExtension)));
+    }
 
     @Auth
     @PostMapping

--- a/src/main/java/com/adventours/calendar/calendar/presentation/StorageBucketClient.java
+++ b/src/main/java/com/adventours/calendar/calendar/presentation/StorageBucketClient.java
@@ -1,0 +1,28 @@
+package com.adventours.calendar.calendar.presentation;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class StorageBucketClient {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public URL generatePresignedUrl(String objectName) {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 30; // 30분
+        expiration.setTime(expTimeMillis);
+        return s3Client.generatePresignedUrl(bucketName, objectName, expiration, HttpMethod.PUT);
+    }
+}

--- a/src/main/java/com/adventours/calendar/calendar/service/AwsS3Service.java
+++ b/src/main/java/com/adventours/calendar/calendar/service/AwsS3Service.java
@@ -1,0 +1,26 @@
+package com.adventours.calendar.calendar.service;
+
+import com.adventours.calendar.calendar.presentation.StorageBucketClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+    private final StorageBucketClient storageBucketClient;
+
+    public UploadKeyResponse getPresignedUrl(String fileExtension) {
+        String uploadKey = generateObjectUploadKey();
+        String objectName = uploadKey + "." + fileExtension.toLowerCase();
+        return new UploadKeyResponse(
+                uploadKey,
+                storageBucketClient.generatePresignedUrl(objectName).toString());
+    }
+
+    private String generateObjectUploadKey() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/adventours/calendar/calendar/service/UploadKeyResponse.java
+++ b/src/main/java/com/adventours/calendar/calendar/service/UploadKeyResponse.java
@@ -1,0 +1,4 @@
+package com.adventours.calendar.calendar.service;
+
+public record UploadKeyResponse(String uploadUrl, String uploadKey) {
+}

--- a/src/main/java/com/adventours/calendar/calendar/service/UploadKeyResponse.java
+++ b/src/main/java/com/adventours/calendar/calendar/service/UploadKeyResponse.java
@@ -1,4 +1,4 @@
 package com.adventours.calendar.calendar.service;
 
-public record UploadKeyResponse(String uploadUrl, String uploadKey) {
+public record UploadKeyResponse(String uploadKey, String uploadUrl) {
 }

--- a/src/main/java/com/adventours/calendar/config/AwsConfig.java
+++ b/src/main/java/com/adventours/calendar/config/AwsConfig.java
@@ -1,0 +1,31 @@
+package com.adventours.calendar.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region).build();
+    }
+}

--- a/src/main/java/com/adventours/calendar/gift/domain/Gift.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/Gift.java
@@ -56,7 +56,11 @@ public class Gift extends BaseTime {
         return new Gift(calendar, openAt, GiftType.INIT);
     }
 
-    public void updateContent(final GiftType giftType, final String title, final String textBody, final String contentUrl) {
+    public void updateContent(
+            final GiftType giftType,
+            final String title,
+            final String textBody,
+            final String contentUrl) {
         this.giftType = giftType;
         this.title = title;
         this.textBody = textBody;

--- a/src/main/java/com/adventours/calendar/gift/service/UpdateGiftRequest.java
+++ b/src/main/java/com/adventours/calendar/gift/service/UpdateGiftRequest.java
@@ -6,5 +6,7 @@ public record UpdateGiftRequest(
         GiftType giftType,
         String title,
         String textBody,
-        String contentUrl) {
+        String link,
+        String uploadKey,
+        String extension) {
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,9 +26,9 @@ cloud:
       access-key: ${aws_credentials_access_key}
       secret-key: ${aws_credentials_secret_key}
     region:
-      static: ap-northeast-2
+      static: ${aws_region_static}
     stack:
       auto: false
     s3:
-      bucket: giftmediabucket
-      media-url: https://giftmediabucket.s3.ap-northeast-2.amazonaws.com/
+      bucket: ${aws_s3_bucket}
+      media-url: ${aws_s3_media_url}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,3 +19,15 @@ jwt:
   access-token:
     expire-length: ${jwt_access_token_expire_length}
     secret: ${jwt_access_token_secret}
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${aws_credentials_access_key}
+      secret-key: ${aws_credentials_secret_key}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: giftmediabucket

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,3 +31,4 @@ cloud:
       auto: false
     s3:
       bucket: giftmediabucket
+      media-url: https://giftmediabucket.s3.ap-northeast-2.amazonaws.com/

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,3 +19,15 @@ jwt:
   access-token:
     expire-length: ${jwt_access_token_expire_length}
     secret: ${jwt_access_token_secret}
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${aws_credentials_access_key}
+      secret-key: ${aws_credentials_secret_key}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: giftmediabucket

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,8 +26,9 @@ cloud:
       access-key: ${aws_credentials_access_key}
       secret-key: ${aws_credentials_secret_key}
     region:
-      static: ap-northeast-2
+      static: ${aws_region_static}
     stack:
       auto: false
     s3:
-      bucket: giftmediabucket
+      bucket: ${aws_s3_bucket}
+      media-url: ${aws_s3_media_url}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,5 @@ cloud:
       static: test
     stack:
       auto: false
+    s3:
+      bucket: test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,4 @@ cloud:
       auto: false
     s3:
       bucket: giftmediabucket
+      media-url: https://giftmediabucket.s3.ap-northeast-2.amazonaws.com/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,8 +27,8 @@ cloud:
       access-key: test
       secret-key: test
     region:
-      static: test
+      static: ap-northeast-2
     stack:
       auto: false
     s3:
-      bucket: test
+      bucket: giftmediabucket

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,13 @@ jwt:
   access-token:
     expire-length: 3600000
     secret: secretsecretsecretsecretsecretsecretsecretsecretsecretsecret
+
+cloud:
+  aws:
+    credentials:
+      access-key: test
+      secret-key: test
+    region:
+      static: test
+    stack:
+      auto: false

--- a/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
@@ -16,6 +16,7 @@ import com.adventours.calendar.user.persistence.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,19 @@ class CalendarControllerTest extends ApiTest {
     UserRepository userRepository;
     @Autowired
     JwtTokenIssuer jwtTokenIssuer;
+
+    @Test
+    @Disabled
+    @DisplayName("Presigned URL 생성 성공")
+    void generatePresignedUrl() {
+        RestAssured.given().log().all()
+                .header("Authorization", accessToken)
+                .when()
+                .get("/calendar/presigned-url?file-extension=jpg")
+                .then()
+                .log().all()
+                .statusCode(200);
+    }
 
     @Test
     @DisplayName("캘린더 생성 성공")

--- a/src/test/java/com/adventours/calendar/gift/api/UpdateGiftApi.java
+++ b/src/test/java/com/adventours/calendar/gift/api/UpdateGiftApi.java
@@ -13,7 +13,9 @@ public class UpdateGiftApi {
 
     private String title = "제목";
     private String textBody = "내용";
-    private String contentUrl = null;
+    private String link;
+    private String uploadKey;
+    private String extension;
 
     public UpdateGiftApi calendarId(final long calendarId) {
         this.calendarId = calendarId;
@@ -40,19 +42,29 @@ public class UpdateGiftApi {
         return this;
     }
 
-    public UpdateGiftApi contentUrl(final String contentUrl) {
-        this.contentUrl = contentUrl;
+    public UpdateGiftApi link(final String link) {
+        this.link = link;
         return this;
     }
 
+    public UpdateGiftApi uploadKey(final String uploadKey) {
+        this.uploadKey = uploadKey;
+        return this;
+    }
 
+    public UpdateGiftApi extension(final String extension) {
+        this.extension = extension;
+        return this;
+    }
 
     public void request() {
         final UpdateGiftRequest request = new UpdateGiftRequest(
                 giftType,
                 title,
                 textBody,
-                contentUrl
+                link,
+                uploadKey,
+                extension
         );
 
         RestAssured.given().log().all()


### PR DESCRIPTION
❗️ 이슈 번호
close #42 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

- Presigned URL을 발급받는 API 개발
- 컨텐츠 url 응답


```
{
    "status": {
        "resCode": "HBD200",
        "resMessage": "정상 처리."
    },
    "data": {
        "uploadKey": "d0c99c19-c3ca-416e-8025-66679e4a542c",
        "uploadUrl": "..."
    }
}
```
