### PR TITLE
feat: 선물 개별 조회 기능 구현

### DIFF
--- a/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
+++ b/src/main/java/com/adventours/calendar/gift/domain/GiftPersonalState.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import org.hibernate.type.TrueFalseConverter;
@@ -22,9 +20,8 @@ public class GiftPersonalState {
     @Convert(converter = TrueFalseConverter.class)
     private boolean isOpened = false;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private GiftReact react = GiftReact.NONE;
+    private boolean isReacted = false;
 
     public GiftPersonalState() {
     }

--- a/src/main/java/com/adventours/calendar/gift/persistence/GiftPersonalStateRepository.java
+++ b/src/main/java/com/adventours/calendar/gift/persistence/GiftPersonalStateRepository.java
@@ -19,5 +19,14 @@ public interface GiftPersonalStateRepository extends JpaRepository<GiftPersonalS
             "and ps.user_id = :userId " +
             "and ps.is_opened = 'F'",
             nativeQuery = true)
+
     Long countNotOpenedGift(UUID calendarId, Long userId, LocalDateTime now);
+
+    @Query(value =
+            "select count(*) " +
+                    "from gift_personal_state " +
+                    "where gift_id = :giftId " +
+                    "and react = true",
+            nativeQuery = true)
+    Long countReactedCountByGiftId(Long giftId);
 }

--- a/src/main/java/com/adventours/calendar/gift/persistence/GiftPersonalStateRepository.java
+++ b/src/main/java/com/adventours/calendar/gift/persistence/GiftPersonalStateRepository.java
@@ -26,7 +26,7 @@ public interface GiftPersonalStateRepository extends JpaRepository<GiftPersonalS
             "select count(*) " +
                     "from gift_personal_state " +
                     "where gift_id = :giftId " +
-                    "and react = true",
+                    "and is_reacted = true",
             nativeQuery = true)
     Long countReactedCountByGiftId(Long giftId);
 }

--- a/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
+++ b/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
@@ -2,6 +2,7 @@ package com.adventours.calendar.gift.presentation;
 
 import com.adventours.calendar.auth.Auth;
 import com.adventours.calendar.auth.UserContext;
+import com.adventours.calendar.gift.service.GiftDetailResponse;
 import com.adventours.calendar.gift.service.GiftListResponse;
 import com.adventours.calendar.gift.service.GiftService;
 import com.adventours.calendar.gift.service.UpdateGiftRequest;
@@ -40,11 +41,20 @@ public class GiftController {
     }
 
     @Auth
+    @Deprecated
     @PostMapping("/calendar/{calendarId}/gift/{giftId}/open")
     public ResponseEntity<CommonResponse<Void>> openGift(@PathVariable final String calendarId, @PathVariable final Long giftId) {
         final Long userId = UserContext.getContext();
         giftService.openGift(userId, giftId);
         return ResponseEntity.ok(new CommonResponse<>());
+    }
 
+    @Auth
+    @GetMapping("/calendar/{calendarId}/gift/{giftId}")
+    public ResponseEntity<CommonResponse<GiftDetailResponse>> getGiftDetail(@PathVariable final String calendarId,
+                                                                            @PathVariable final Long giftId) {
+        final Long userId = UserContext.getContext();
+        final GiftDetailResponse giftDetail = giftService.getGiftDetail(userId, giftId);
+        return ResponseEntity.ok(new CommonResponse<>(giftDetail));
     }
 }

--- a/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
+++ b/src/main/java/com/adventours/calendar/gift/presentation/GiftController.java
@@ -41,15 +41,6 @@ public class GiftController {
     }
 
     @Auth
-    @Deprecated
-    @PostMapping("/calendar/{calendarId}/gift/{giftId}/open")
-    public ResponseEntity<CommonResponse<Void>> openGift(@PathVariable final String calendarId, @PathVariable final Long giftId) {
-        final Long userId = UserContext.getContext();
-        giftService.openGift(userId, giftId);
-        return ResponseEntity.ok(new CommonResponse<>());
-    }
-
-    @Auth
     @GetMapping("/calendar/{calendarId}/gift/{giftId}")
     public ResponseEntity<CommonResponse<GiftDetailResponse>> getGiftDetail(@PathVariable final String calendarId,
                                                                             @PathVariable final Long giftId) {

--- a/src/main/java/com/adventours/calendar/gift/service/GiftDetailResponse.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftDetailResponse.java
@@ -13,7 +13,7 @@ public record GiftDetailResponse(
         String contentUrl,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        Boolean isMyGift,
+        Boolean isMyCalendar,
         Boolean isReacted,
         Long reactCount
 ) {

--- a/src/main/java/com/adventours/calendar/gift/service/GiftDetailResponse.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftDetailResponse.java
@@ -1,0 +1,20 @@
+package com.adventours.calendar.gift.service;
+
+import com.adventours.calendar.gift.domain.GiftType;
+
+import java.time.LocalDateTime;
+
+public record GiftDetailResponse(
+        Long giftId,
+        LocalDateTime openAt,
+        GiftType giftType,
+        String title,
+        String textBody,
+        String contentUrl,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        Boolean isMyGift,
+        Boolean isReacted,
+        Long reactCount
+) {
+}

--- a/src/main/java/com/adventours/calendar/gift/service/GiftListResponse.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftListResponse.java
@@ -1,20 +1,12 @@
 package com.adventours.calendar.gift.service;
 
-import com.adventours.calendar.gift.domain.GiftReact;
-import com.adventours.calendar.gift.domain.GiftType;
-
 import java.time.LocalDateTime;
 
 public record GiftListResponse(
         Long giftId,
         LocalDateTime openAt,
-        GiftType giftType,
-        String title,
-        String textBody,
-        String contentUrl,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        boolean isOpened,
-        GiftReact react
+        boolean isOpened
 ) {
 }

--- a/src/main/java/com/adventours/calendar/gift/service/GiftService.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftService.java
@@ -78,9 +78,13 @@ public class GiftService {
     public GiftDetailResponse getGiftDetail(Long userId, Long giftId) {
         final User user = userRepository.getReferenceById(userId);
         final Gift gift = giftRepository.findById(giftId).orElseThrow(NotFoundGiftException::new);
-        final boolean isMyGift = gift.getCalendar().getUser().equals(user);
-        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, user)).orElse(new GiftPersonalState());
-        giftPersonalState.open();
+        final boolean isMyCalendar = gift.getCalendar().getUser().equals(user);
+        boolean isReacted = false;
+        if (!isMyCalendar) {
+            final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, user)).orElse(new GiftPersonalState());
+            giftPersonalState.open();
+            isReacted = giftPersonalState.isReacted();
+        }
         return new GiftDetailResponse(
                 gift.getId(),
                 gift.getOpenAt(),
@@ -90,9 +94,9 @@ public class GiftService {
                 gift.getContentUrl(),
                 gift.getCreatedAt(),
                 gift.getUpdatedAt(),
-                isMyGift,
-                giftPersonalState.isReacted(),
-                isMyGift ? giftPersonalStateRepository.countReactedCountByGiftId(gift.getId()) : null
+                isMyCalendar,
+                isReacted,
+                isMyCalendar ? giftPersonalStateRepository.countReactedCountByGiftId(gift.getId()) : null
         );
     }
 }

--- a/src/main/java/com/adventours/calendar/gift/service/GiftService.java
+++ b/src/main/java/com/adventours/calendar/gift/service/GiftService.java
@@ -75,14 +75,6 @@ public class GiftService {
     }
 
     @Transactional
-    public void openGift(final Long userId, final Long giftId) {
-        final User user = userRepository.getReferenceById(userId);
-        final Gift gift = giftRepository.getReferenceById(giftId);
-        final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findById(new GiftPersonalStatePk(gift, user)).orElseThrow();
-        giftPersonalState.open();
-    }
-
-    @Transactional
     public GiftDetailResponse getGiftDetail(Long userId, Long giftId) {
         final User user = userRepository.getReferenceById(userId);
         final Gift gift = giftRepository.findById(giftId).orElseThrow(NotFoundGiftException::new);

--- a/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
+++ b/src/test/java/com/adventours/calendar/gift/GiftControllerTest.java
@@ -64,8 +64,8 @@ class GiftControllerTest extends ApiTest {
     }
 
     @Test
-    @DisplayName("선물 열기 성공")
-    void openGift() {
+    @DisplayName("구독한 선물 열기 성공")
+    void openGift_sub() {
         final User user = Scenario.createUserDB().id(2L).create();
         final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
         Scenario.subscribeCalendar().calendarId(calendar.getId()).request().
@@ -74,5 +74,14 @@ class GiftControllerTest extends ApiTest {
         final GiftPersonalState giftPersonalState = giftPersonalStateRepository.findAll().get(0);
 
         assertThat(giftPersonalState.isOpened()).isTrue();
+    }
+
+    @Test
+    @DisplayName("내 선물 열기 성공")
+    void openGift_my() {
+        final User user = userRepository.getReferenceById(1L);
+        final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
+        Scenario.subscribeCalendar().calendarId(calendar.getId()).request().
+                openGift().calendarId(calendar.getTitle()).request();
     }
 }

--- a/src/test/java/com/adventours/calendar/gift/api/OpenGiftApi.java
+++ b/src/test/java/com/adventours/calendar/gift/api/OpenGiftApi.java
@@ -24,7 +24,7 @@ public class OpenGiftApi {
         RestAssured.given().log().all()
                 .header("Authorization", accessToken)
                 .when()
-                .post("/calendar/{calendarId}/gift/{giftId}/open", calendarId, giftId)
+                .get("/calendar/{calendarId}/gift/{giftId}", calendarId, giftId)
                 .then()
                 .log().all()
                 .statusCode(200);


### PR DESCRIPTION
❗️ 이슈 번호
close #46


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

- `선물 개별 조회(열람)` api 구현
    - `선물 열람` api 삭제. 해당 조회 기능 사용하면 내부적으로 열람 처리
- `특정 캘린더의 선물 목록 조회` 변경사항
    - `특정 캘린더의 선물 목록 조회` 의 컬럼 간소화
    - `REACT` 삭제 → `isReacted` boolean 필드로 변경