### PR TITLE
feat: 구독 취소 api 구현

### DIFF
--- a/src/main/java/com/adventours/calendar/calendar/presentation/CalendarController.java
+++ b/src/main/java/com/adventours/calendar/calendar/presentation/CalendarController.java
@@ -13,6 +13,7 @@ import com.adventours.calendar.global.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,6 +76,14 @@ public class CalendarController {
     public ResponseEntity<CommonResponse<Void>> subscribeCalendar(@PathVariable final String calendarId) {
         final Long userId = UserContext.getContext();
         calendarService.subscribe(userId, calendarId);
+        return ResponseEntity.ok(new CommonResponse<>());
+    }
+
+    @Auth
+    @DeleteMapping("/sub/{calendarId}")
+    public ResponseEntity<CommonResponse<List<SubCalendarListResponse>>> unsubscribeCalendar(@PathVariable final String calendarId) {
+        final Long userId = UserContext.getContext();
+        calendarService.unsubscribe(userId, calendarId);
         return ResponseEntity.ok(new CommonResponse<>());
     }
 }

--- a/src/main/java/com/adventours/calendar/calendar/service/CalendarService.java
+++ b/src/main/java/com/adventours/calendar/calendar/service/CalendarService.java
@@ -142,4 +142,10 @@ public class CalendarService {
         }
         giftPersonalStateRepository.saveAll(giftPersonalStateList);
     }
+
+    public void unsubscribe(Long userId, String calendarId) {
+        final User user = userRepository.getReferenceById(userId);
+        final Calendar calendar = calendarRepository.getReferenceById(UUID.fromString(calendarId));
+        subscribeRepository.delete(new Subscribe(new SubscribePk(user, calendar)));
+    }
 }

--- a/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
+++ b/src/test/java/com/adventours/calendar/calendar/CalendarControllerTest.java
@@ -169,4 +169,23 @@ class CalendarControllerTest extends ApiTest {
         assertThat(calendarRepository.findById(calendar.getId()).get().getTitle()).isEqualTo("수정된 제목");
         assertThat(calendarRepository.findById(calendar.getId()).get().getTemplate()).isEqualTo(CalendarTemplate.GREEN);
     }
+
+    @Test
+    @DisplayName("캘린더 구독 취소 성공")
+    void unsubscribeCalendar() {
+        final User user = Scenario.createUserDB().id(2L).create();
+        final Calendar calendar = Scenario.createCalendarDB().uuid(UUID.randomUUID()).user(user).create();
+        Scenario.subscribeCalendar().calendarId(calendar.getId()).request();
+        assertThat(subscribeRepository.count()).isOne();
+
+        RestAssured.given().log().all()
+                .header("Authorization", accessToken)
+                .when()
+                .delete("/calendar/sub/{calendarId}", calendar.getId())
+                .then()
+                .log().all()
+                .statusCode(200);
+
+        assertThat(subscribeRepository.count()).isZero();
+    }
 }


### PR DESCRIPTION
❗️ 이슈 번호
close #48


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
- 기존 캘린더를 구독 취소합니다.
- react / 열람 정보는 그대로 유지됩니다.



